### PR TITLE
エラーメッセージが正しく表示されていなかったため修正

### DIFF
--- a/lib/feature/news_api/repository/news_everything_repository.dart
+++ b/lib/feature/news_api/repository/news_everything_repository.dart
@@ -23,7 +23,7 @@ class NewsEverythingRepository {
     dio.interceptors.add(LogInterceptor(logPrint: logger.d));
     final client = NewsEverythingClient(dio);
     try {
-      final response = client.get(
+      final response = await client.get(
         apiKey: AppConfig.instance.newsApiKey,
         query: query,
         pageSize: 100,

--- a/lib/feature/news_api/repository/news_top_headlines_repository.dart
+++ b/lib/feature/news_api/repository/news_top_headlines_repository.dart
@@ -23,7 +23,7 @@ class NewsTopHeadlinesRepository {
     dio.interceptors.add(LogInterceptor(logPrint: logger.d));
     final client = NewsTopHeadlinesClient(dio);
     try {
-      final response = client.get(
+      final response = await client.get(
         apiKey: AppConfig.instance.newsApiKey,
         country: 'jp',
         category: category,

--- a/lib/feature/news_article_list/riverpod/news_articles_notifier.dart
+++ b/lib/feature/news_article_list/riverpod/news_articles_notifier.dart
@@ -43,21 +43,22 @@ class NewsArticlesNotifier extends _$NewsArticlesNotifier {
 
       state = AsyncValue<NewsArticles>.data(newsArticles);
       return Future.value();
-    } on Exception catch (e) {
+    } on Exception catch (error) {
       appLogger.e(
         [
           '$_notifierName#fetch',
-          {'category': category, 'Exception': e},
+          {'category': category, 'Exception': error},
         ],
       );
       final appException =
-          e is AppException ? e : AppException(parentException: e);
+          error is AppException ? error : AppException(parentException: error);
 
       if (isRefresh) {
-        state = AsyncValue<NewsArticles>.error(e, StackTrace.current)
+        state = AsyncValue<NewsArticles>.error(appException, StackTrace.current)
             .copyWithPrevious(state);
       } else {
-        state = AsyncValue<NewsArticles>.error(e, StackTrace.current);
+        state =
+            AsyncValue<NewsArticles>.error(appException, StackTrace.current);
       }
       return Future.error(appException);
     }

--- a/lib/feature/news_article_list/widget/news_article_list_page.dart
+++ b/lib/feature/news_article_list/widget/news_article_list_page.dart
@@ -162,14 +162,42 @@ Widget _body(
             final appException = error is AppException
                 ? error
                 : AppException(parentException: error as Exception);
-            return Center(
-              child: Text(appException.messageByTranslations(translations)),
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: constraints.maxHeight,
+                    ),
+                    child: Center(
+                      child: Text(
+                        appException.messageByTranslations(translations),
+                      ),
+                    ),
+                  ),
+                );
+              },
             );
           },
           data: (data) {
             if (data.items.isEmpty) {
-              return Center(
-                child: Text(translations.general.noDataAvailable),
+              return LayoutBuilder(
+                builder: (context, constraints) {
+                  return SingleChildScrollView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
+                      child: Center(
+                        child: Text(
+                          translations.general.noDataAvailable,
+                        ),
+                      ),
+                    ),
+                  );
+                },
               );
             }
 

--- a/lib/feature/news_article_search/riverpod/news_articles_notifier.dart
+++ b/lib/feature/news_article_search/riverpod/news_articles_notifier.dart
@@ -45,20 +45,20 @@ class NewsArticlesNotifier extends _$NewsArticlesNotifier {
 
       state = AsyncValue<NewsArticles>.data(newsArticles);
       return Future.value();
-    } on Exception catch (e) {
+    } on Exception catch (error) {
       appLogger.e(
         [
           '$_notifierName#fetch',
-          {'Exception': e},
+          {'Exception': error},
         ],
       );
       final appException =
-          e is AppException ? e : AppException(parentException: e);
+          error is AppException ? error : AppException(parentException: error);
       if (isRefresh) {
-        state = AsyncValue<NewsArticles>.error(e, StackTrace.current)
+        state = AsyncValue<NewsArticles>.error(error, StackTrace.current)
             .copyWithPrevious(state);
       } else {
-        state = AsyncValue<NewsArticles>.error(e, StackTrace.current);
+        state = AsyncValue<NewsArticles>.error(error, StackTrace.current);
       }
       return Future.error(appException);
     }


### PR DESCRIPTION
- news_top_headlines_repository, news_everything_repository で await 漏れ
- その repository でのエラー埋め込みができてなかった
- ニュース記事一覧でエラー時の pull refresh できるように修正