### PR TITLE
GitHub Pages へのデプロイを削除し、コードカバレッジを出力しない

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: Test, Deploy GitHub Pages
+name: Test
 
 on:
   pull_request:
@@ -53,47 +53,3 @@ jobs:
         with:
           name: coverage
           path: coverage
-
-  build_github_pages:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      pages: write
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download coverage from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage
-          path: coverage
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-
-  deploy_github_pages:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build_github_pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      pages: write
-      id-token: write
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@
 
 - [ローカル開発環境構築](doc/local_development_setup.md)
 
-## テスト
-
-- [カバレッジ](https://greendrop.github.io/flutter_news_sample/coverage/html)
-
 ## トピック
 
 - [非スマホエンジニア向けのトピック](doc/topics/topics_for_non_smartphone_engineers.md)


### PR DESCRIPTION
- GitHub Actions workflow で Test と GitHub Pages へのデプロイが分離しにくい
- コードカバレッジは Pull Resuest への表示でも問題ない
- GitHub Pages へのデプロイを削除