### PR TITLE
actionlint のダウンロード方法を変更

### DIFF
--- a/.github/workflows/github_actions_lint.yml
+++ b/.github/workflows/github_actions_lint.yml
@@ -32,11 +32,25 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        # NOTE: アップデートする場合は、GHALINT_VERSION, GHALINT_CHECKSUM を更新してください
+        env:
+          ACTIONLINT_VERSION: 1.7.1
+          ACTIONLINT_OS: linux
+          ACTIONLINT_ARCH: amd64
+          ACTIONLINT_CHECKSUM: f53c34493657dfea83b657e4b62cc68c25fbc383dff64c8d581613b037aacaa3
+        run: |
+          curl -L -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${ACTIONLINT_OS}_${ACTIONLINT_ARCH}.tar.gz"
+          if [ "$(shasum -a 256 actionlint.tar.gz)" != "${ACTIONLINT_CHECKSUM}  actionlint.tar.gz" ]; then
+            echo "checksum mismatch"
+            echo "expected: ${ACTIONLINT_CHECKSUM}  ghalint.tar.gz"
+            echo "actual: $(shasum -a 256 actionlint.tar.gz)"
+            exit 1
+          fi
+          tar xzf actionlint.tar.gz
+          ./actionlint -version
 
       - name: Run actionlint
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: ./actionlint -color
 
       - name: Download ghalint
         # NOTE: アップデートする場合は、GHALINT_VERSION, GHALINT_CHECKSUM を更新してください


### PR DESCRIPTION
- curl で取得した bash を実行する方法から、 curl でバイナリをダウンロードするように変更
- ダウンロード時に、バージョン指定し、チェックサムで改ざんされていないことを確認