### PR TITLE
feat: analysis_options.yamlの設定を統一し、カスタムLintを追加

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,18 @@
+---
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  plugins:
+    - custom_lint
+  exclude:
+    - "**/*.freezed.dart"
+    - "**/*.g.dart"
+    - "**/*.gen.dart"
+    - "**/*.gr.dart"
+    - "**/*.mocks.dart"
+    - "lib/generated_plugin_registrant.dart"
+linter:
+  rules:
+    depend_on_referenced_packages: false
+    public_member_api_docs: false
+    # dart format と require_trailing_commas が競合するため無効化
+    require_trailing_commas: false

--- a/packages/app/analysis_options.yaml
+++ b/packages/app/analysis_options.yaml
@@ -1,18 +1,2 @@
 ---
-include: package:very_good_analysis/analysis_options.yaml
-analyzer:
-  plugins:
-    - custom_lint
-  exclude:
-    - "**/*.freezed.dart"
-    - "**/*.g.dart"
-    - "**/*.gen.dart"
-    - "**/*.gr.dart"
-    - "**/*.mocks.dart"
-    - "lib/generated_plugin_registrant.dart"
-linter:
-  rules:
-    depend_on_referenced_packages: false
-    public_member_api_docs: false
-    # dart format と require_trailing_commas が競合するため無効化
-    require_trailing_commas: false
+include: ../../analysis_options.yaml

--- a/packages/app/test/support/widget/test_provider_scope.dart
+++ b/packages/app/test/support/widget/test_provider_scope.dart
@@ -18,8 +18,6 @@ class TestProviderScope extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return ProviderScope(
       overrides: [
-        // テスト用のLoggerで上書きするため
-        // ignore: scoped_providers_should_specify_dependencies
         appLoggerProvider.overrideWithValue(buildAppTestLogger()),
         ...providerScopeOverrides,
       ],

--- a/packages/widgetbook/analysis_options.yaml
+++ b/packages/widgetbook/analysis_options.yaml
@@ -1,11 +1,2 @@
 ---
-include: package:very_good_analysis/analysis_options.yaml
-analyzer:
-  exclude:
-    - /**/*.g.dart
-linter:
-  rules:
-    depend_on_referenced_packages: false
-    public_member_api_docs: false
-    # dart format と require_trailing_commas が競合するため無効化
-    require_trailing_commas: false
+include: ../../analysis_options.yaml

--- a/packages/widgetbook/pubspec.yaml
+++ b/packages/widgetbook/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.14
+  custom_lint: ^0.7.5
   flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
- analysis_options.yamlを新規作成し、共通の設定を追加
- appパッケージのanalysis_options.yamlを共通設定を参照するように変更
- widgetbookパッケージのanalysis_options.yamlを共通設定を参照するように変更
- widgetbookパッケージのpubspec.yamlにcustom_lintを追加
- TestProviderScopeでのLoggerの上書きコメントを削除